### PR TITLE
Make GitHub detect *.SCR as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.SCR linguist-language=Forth
+*.SML linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `.SCR` files as Forth.

Thank you!
